### PR TITLE
Added math.randomseed call to init

### DIFF
--- a/CombatMod/Mods/CombatMod/ScriptExtender/Lua/CombatMod/_Server.lua
+++ b/CombatMod/Mods/CombatMod/ScriptExtender/Lua/CombatMod/_Server.lua
@@ -77,6 +77,7 @@ local function init()
         return
     end
     done = true
+    math.randomseed(os.time())
 
     Require("CombatMod/Overwrites")
 


### PR DESCRIPTION
Hello, just following up on a post on your Nexus page --

It looks like you're calling math.random to select which items appear in loot, but I don't see a call to math.randomseed anywhere.  So I think maybe the server is just generating the same sequence of random numbers every time (hence, the repeated loot drops within the same run).  What if you added a math.randomseed(os.time()) call that just runs once at startup?

(Note: I don't have a local dev environment set up so I haven't actually tested this -- just wanted to send you a PR in case it wasn't clear what I was saying)